### PR TITLE
🛂 fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Vaalley/kohai-ui/security/code-scanning/1](https://github.com/Vaalley/kohai-ui/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs a `deno fmt --check` operation, it only requires `contents: read` permissions. This change will ensure that the workflow adheres to the principle of least privilege by explicitly limiting the permissions of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
